### PR TITLE
Feature/04 pagination

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -56,6 +56,9 @@ gem 'activestorage-validator'
 # binding.pry
 gem 'pry-rails'
 
+# ページネーション
+gem 'pagy'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,8 @@ GEM
       multi_json (~> 1.3)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 3)
+    pagy (5.10.1)
+      activesupport
     parallel (1.22.1)
     parser (3.1.2.0)
       ast (~> 2.4.1)
@@ -326,6 +328,7 @@ DEPENDENCIES
   importmap-rails
   jbuilder
   mysql2 (~> 0.5)
+  pagy
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.3)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,5 @@
 
 class ApplicationController < ActionController::Base
   add_flash_types :primary, :success, :warning, :danger
+  include Pagy::Backend
 end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,7 +1,7 @@
 class PostsController < ApplicationController
   before_action :require_login, only: %i[new create edit update destroy]
   def index
-    @posts = Post.with_attached_images.includes(:user).order(created_at: :desc)
+    @pagy, @posts = pagy(Post.with_attached_images.includes(:user).order(created_at: :desc))
   end
 
   def new

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  include Pagy::Frontend
 end

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -2,6 +2,7 @@
   <div class="row">
     <div class="col-12">
       <%= render @posts %>
+      <%== pagy_bootstrap_nav(@pagy) %>
     </div>
   </div>
 </div>

--- a/config/initializers/pagy.rb
+++ b/config/initializers/pagy.rb
@@ -1,0 +1,3 @@
+Pagy::DEFAULT[:items] = 15
+require 'pagy/extras/bootstrap'
+require 'pagy/extras/i18n'

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -31,14 +31,6 @@ RSpec.describe '投稿', type: :system do
     end
   end
 
-  describe '詳細' do
-
-  end
-
-  describe '一覧' do
-
-  end
-
   describe '削除' do
     let!(:post) { create(:post, user: user) }
     it '削除ができること' do
@@ -47,6 +39,17 @@ RSpec.describe '投稿', type: :system do
       accept_confirm { click_on '削除' }
       expect(page).to have_content '投稿を削除しました'
       expect(page).not_to have_content post.body
+    end
+  end
+
+  describe 'ページネーション' do
+    let!(:post) { create(:post, created_at: Time.current.yesterday) }
+    before do
+      create_list(:post, 15)
+    end
+    it '16件目のポストは1ページ目に表示されていないこと' do
+      visit '/posts'
+      expect(page).not_to have_css("#post_#{post.id}")
     end
   end
 end


### PR DESCRIPTION
## 概要
### 投稿のページネーション機能を実装しました。

[![Image from Gyazo](https://i.gyazo.com/ac2e5d0b80002b3480c4dcaf5f6151cd.gif)](https://gyazo.com/ac2e5d0b80002b3480c4dcaf5f6151cd)

### `pagy`というgemを使用しました。

## 確認方法

1. Gem を追加したので `bundle install` を実行してください

2. 投稿を30個くらい`rails console`で作ってページネーションが機能していることを確認してください。
`FactoryBot`の`creat_list`を使うと簡単に作れます。

## チェックリスト

- [x] テストを書いた
- [x] Lint のチェックをパスした

## コメント
gemのkaminariより実装が簡単で、処理も早いらしいということで、便利だなーと感じた。

## 質問
specの書き方の部分で２点よろしくお願いします！
https://github.com/DaichiSaito/insta_clone_ver7/pull/5#discussion_r936921887

https://github.com/DaichiSaito/insta_clone_ver7/pull/5#discussion_r936924370