### PR TITLE
add 検索機能

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -60,6 +60,9 @@ gem 'pry-rails'
 # ページネーション
 gem 'pagy'
 
+# 検索
+gem 'ransack'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -230,6 +230,10 @@ GEM
       zeitwerk (~> 2.5)
     rainbow (3.1.1)
     rake (13.0.6)
+    ransack (3.2.1)
+      activerecord (>= 6.1.5)
+      activesupport (>= 6.1.5)
+      i18n
     redis (4.6.0)
     regexp_parser (2.5.0)
     reline (0.3.1)
@@ -336,6 +340,7 @@ DEPENDENCIES
   puma (~> 5.0)
   rails (~> 7.0.2, >= 7.0.2.3)
   rails-i18n
+  ransack
   redis (~> 4.0)
   rspec-rails
   rubocop

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,11 +1,12 @@
 class PostsController < ApplicationController
   before_action :require_login, only: %i[new create edit update destroy]
   def index
-    @pagy, @posts = if logged_in?
-                      pagy(current_user.feed.with_attached_images.includes(:user).order(created_at: :desc))
-                    else
-                      pagy(Post.with_attached_images.includes(:user).order(created_at: :desc))
-                    end
+    @q = if logged_in?
+           current_user.feed.ransack(params[:q])
+         else
+           Post.ransack(params[:q])
+         end
+    @pagy, @posts = pagy(@q.result(distinct: true).with_attached_images.includes(:user).order(created_at: :desc))
   end
 
   def new

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -45,7 +45,6 @@
           <i class="fas fa-search"></i>
         </a>
         <%= render 'shared/search_modal', q: @q %>
-        
         <% if logged_in? %>
           <%= link_to new_post_path, class: 'btn btn-primary btn-sm me-3' do %>
             <i class="fas fa-camera me-2"></i>

--- a/app/views/layouts/_header.html.erb
+++ b/app/views/layouts/_header.html.erb
@@ -35,6 +35,17 @@
           <%= link_to 'サインアップ', signup_path, class: 'btn btn-primary me-3' %>
         <% end %>
 
+        <a
+          href="#"
+          id="search-icon"
+          class="input-group-text border-0"
+          data-mdb-toggle="modal"
+          data-mdb-target="#searchModal"
+          data-mdb-whatever="@mdo">
+          <i class="fas fa-search"></i>
+        </a>
+        <%= render 'shared/search_modal', q: @q %>
+        
         <% if logged_in? %>
           <%= link_to new_post_path, class: 'btn btn-primary btn-sm me-3' do %>
             <i class="fas fa-camera me-2"></i>

--- a/app/views/shared/_search_modal.html.erb
+++ b/app/views/shared/_search_modal.html.erb
@@ -1,0 +1,29 @@
+<div class="modal fade" id="searchModal" tabindex="-1" aria-labelledby="searchModalLabel" aria-hidden="true">
+  <div class="modal-dialog">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title" id="searchModalLabel">検索</h5>
+        <button type="button" class="btn-close" data-mdb-dismiss="modal" aria-label="Close"></button>
+      </div>
+      <div class="modal-body">
+        <%= search_form_for q || Post.ransack do |f| %>
+          <div class="mb-3 form-outline">
+            <%= f.search_field :body_cont, class: 'form-control' %>
+            <%= f.label :body_cont, '投稿の本文', class: 'form-label' %>
+          </div>
+          <div class="mb-3 form-outline">
+            <%= f.search_field :comments_body_cont, class: 'form-control' %>
+            <%= f.label :comments_body_cont, 'コメント', class: 'form-label' %>
+          </div>
+          <div class="mb-3 form-outline">
+            <%= f.search_field :user_username_cont, class: 'form-control' %>
+            <%= f.label :user_username_cont, 'ユーザー名', class: 'form-label' %>
+          </div>
+          <div class="text-center">
+            <%= f.submit '検索', class: 'btn btn-primary' %>
+          </div>
+        <% end %>
+      </div>
+    </div>
+  </div>
+</div>

--- a/spec/system/posts_spec.rb
+++ b/spec/system/posts_spec.rb
@@ -52,4 +52,87 @@ RSpec.describe '投稿', type: :system do
       expect(page).not_to have_css("#post_#{post.id}")
     end
   end
+
+  describe '検索' do
+    describe '投稿の本文での検索' do
+      let!(:post_a) { create(:post, body: 'おはよう') }
+      let!(:post_b) { create(:post, body: 'こんにちは') }
+      let!(:post_c) { create(:post, body: 'こんばんは') }
+      before do
+        User.all.each { |u| user.follow(u) }
+      end
+      it '投稿の本文での検索ができること' do
+        visit '/posts'
+        find('#search-icon').click
+        within '#searchModal' do
+          fill_in '投稿の本文', with: 'おは'
+          click_on '検索'
+        end
+        expect(page).to have_css "#post_#{post_a.id}"
+        expect(page).not_to have_css "#post_#{post_b.id}"
+        expect(page).not_to have_css "#post_#{post_c.id}"
+      end
+    end
+
+    describe 'コメントでの検索' do
+      let!(:post_a) do
+        post = create(:post)
+        create(:comment, post: post, body: 'GoodMorning')
+        post
+      end
+      let!(:post_b) do
+        post = create(:post)
+        create(:comment, post: post, body: 'Hello')
+        post
+      end
+      let!(:post_c) do
+        post = create(:post)
+        create(:comment, post: post, body: 'GoodEvening')
+        post
+      end
+      before do
+        User.all.each { |u| user.follow(u) }
+      end
+      it 'コメントでの検索ができること' do
+        visit '/posts'
+        find('#search-icon').click
+        within '#searchModal' do
+          fill_in 'コメント', with: 'GoodMorning'
+          click_on '検索'
+        end
+        expect(page).to have_css "#post_#{post_a.id}"
+        expect(page).not_to have_css "#post_#{post_b.id}"
+        expect(page).not_to have_css "#post_#{post_c.id}"
+      end
+    end
+
+    describe '投稿者のユーザー名での検索' do
+      let!(:post_a) do
+        user = create(:user, username: 'taro')
+        create(:post, user: user)
+      end
+      let!(:post_b) do
+        user = create(:user, username: 'jiro')
+        create(:post, user: user)
+      end
+      let!(:post_c) do
+        user = create(:user, username: 'saburo')
+        create(:post, user: user)
+      end
+      before do
+        User.all.each { |u| user.follow(u) }
+      end
+      it '投稿者のユーザー名での検索ができること' do
+        visit '/posts'
+        find('#search-icon').click
+        within '#searchModal' do
+          fill_in 'ユーザー名', with: 'taro'
+          click_on '検索'
+        end
+        expect(page).to have_css "#post_#{post_a.id}"
+        expect(page).not_to have_css "#post_#{post_b.id}"
+        expect(page).not_to have_css "#post_#{post_c.id}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
## 概要
投稿の検索機能を実装しました。

[![Image from Gyazo](https://i.gyazo.com/cc7151ec895f0edae278dfca4a0f94ce.gif)](https://gyazo.com/cc7151ec895f0edae278dfca4a0f94ce)

- 全ての投稿を検索対象としました（フィードに対する検索ではない）
- 検索条件としては以下の三つとしました
  - 本文に検索ワードが含まれている投稿
  - コメントに検索ワードが含まれている投稿
  - 投稿者の名前に検索ワードが含まれている投稿
- ransackを利用しました


## 確認方法

1. gemを追加したので `bundle` を実行してください

仕様通りに検索できること。

## チェックリスト

- [x] テストを書いた
- [x] Lint のチェックをパスした

## コメント
検索の半角スペースで複数検索をやってみようと思ったが、うまくいかなかった。。。
ひとまず、飛ばして次に進もうと思った。