### PR TITLE
add redisとsidekiqのコンテナ追加

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,6 +74,9 @@ gem 'letter_opener_web'
 # 定数管理
 gem 'config'
 
+# ワーカー
+gem 'sidekiq'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'annotate'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -106,6 +106,7 @@ GEM
     config (4.0.0)
       deep_merge (~> 1.2, >= 1.2.1)
       dry-validation (~> 1.0, >= 1.0.0)
+    connection_pool (2.3.0)
     crass (1.0.6)
     debug (1.4.0)
       irb (>= 1.3.6)
@@ -347,6 +348,10 @@ GEM
       rexml (~> 3.2, >= 3.2.5)
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
+    sidekiq (6.5.7)
+      connection_pool (>= 2.2.5)
+      rack (~> 2.0)
+      redis (>= 4.5.0, < 5)
     smart_properties (1.17.0)
     sorcery (0.16.3)
       bcrypt (~> 3.1)
@@ -419,6 +424,7 @@ DEPENDENCIES
   rubocop
   rubocop-rails
   selenium-webdriver
+  sidekiq
   sorcery
   sprockets-rails
   stimulus-rails

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -72,4 +72,6 @@ Rails.application.configure do
 
   config.action_mailer.default_url_options = Settings.default_url_options.to_h
   config.action_mailer.delivery_method = :letter_opener_web
+
+  config.active_job.queue_adapter = :sidekiq
 end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -60,4 +60,6 @@ Rails.application.configure do
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true
+
+  config.active_job.queue_adapter = :test
 end

--- a/config/initializers/sidekiq.rb
+++ b/config/initializers/sidekiq.rb
@@ -1,0 +1,7 @@
+Sidekiq.configure_server do |config|
+  config.redis = { url: ENV['REDIS_URL']}
+end
+
+Sidekiq.configure_client do |config|
+  config.redis = { url: ENV['REDIS_URL'] }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,8 @@ Rails.application.routes.draw do
   end
 
   if Rails.env.development?
+    require 'sidekiq/web'
     mount LetterOpenerWeb::Engine, at: '/letter_opener'
+    mount Sidekiq::Web, at: '/sidekiq'
   end
 end

--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -1,0 +1,5 @@
+:concurrency: 5
+:queues:
+  - default
+  - active_storage_analysis
+  - active_storage_purge

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,13 @@ services:
     depends_on:
       - db
       - chrome
+      - redis
+      - sidekiq
     stdin_open: true
     tty: true
     environment:
       SELENIUM_DRIVER_URL: http://chrome:4444/wd/hub
+      REDIS_URL: redis://redis:6379
   db:
     image: mysql:5.7.33
     environment:
@@ -27,6 +30,25 @@ services:
     image: selenium/standalone-chrome-debug:latest
     ports:
       - 4444:4444
+  sidekiq:
+    build: .
+    environment:
+      REDIS_URL: redis://redis:6379
+    volumes:
+      - .:/insta_clone:cached
+      - bundle:/usr/local/bundle
+    depends_on:
+      - db
+      - redis
+    command: bundle exec sidekiq -C config/sidekiq.yml
+  redis:
+    image: redis:latest
+    ports:
+      - 6379:6379
+    volumes:
+      - redis:/data
 volumes:
   bundle:
   mysql_data:
+  redis:
+  


### PR DESCRIPTION
## 概要
`sidekiq`を導入し、ActiveJobのジョブが永続化されるようにしました。
以下のジョブを永続化するようにしています。
- メール
- ActiveStorageの`active_storage_analysis`, `active_storage_purge `処理


## 確認方法

1. コンテナを追加したので `docker-compose build`を実行してください

2. gemを追加したので `bundle` を実行してください

`/sidekiq`からジョブの実行結果が確認できます。

[![Image from Gyazo](https://i.gyazo.com/10d2cec7f0e78c6f08278a8bf23e11ee.png)](https://gyazo.com/10d2cec7f0e78c6f08278a8bf23e11ee)

[![Image from Gyazo](https://i.gyazo.com/40a28249094da5507da8e4e263db3918.png)](https://gyazo.com/40a28249094da5507da8e4e263db3918)

## チェックリスト

- [ ] テストを書いた
- [x] Lint のチェックをパスした

## コメント
特になし
